### PR TITLE
Fix loading stats file with py3.5

### DIFF
--- a/pyramid_webpack/__init__.py
+++ b/pyramid_webpack/__init__.py
@@ -128,7 +128,7 @@ class WebpackState(object):
         for attempt in range(0, 3):
             try:
                 with self.stats_file.open() as f:
-                    return json.load(f)
+                    return json.loads(f.read().decode())
             except ValueError:
                 # If we failed to parse the JSON, it's possible that the
                 # webpack process is writing to it concurrently and it's in a


### PR DESCRIPTION
Loading the stats file (e.g. when iterating over `request.webpack().get_bundle('main')`) resulted in an error with python 3.5:

```
TypeError: the JSON object must be str, not 'bytes'
```

This is because `json.loads(b'{}')` works with py3.6 but not 3.5. This PR fixes the issue.

Didn't test with other Python versions than 3.5.